### PR TITLE
Fixing validation function referenced name

### DIFF
--- a/src/language/data-space-validator.ts
+++ b/src/language/data-space-validator.ts
@@ -10,7 +10,7 @@ export function registerValidationChecks(services: DataSpaceServices) {
     const validator = services.validation.DataSpaceValidator;
     const checks: ValidationChecks<DataSpaceAstType> = {
         Model: [
-            validator.validateUniqueSchemasInModel,
+            validator.validateUniqueElementsInModel,
         ],
         Schema: [
             validator.validateCapitalizedSchemas,


### PR DESCRIPTION
If this is intentional please close this PR.

The guide asks to build directly after cloning and the project should run fine. But an error occures because one of the functions registered in data-space-validators doesnt exist. 

Looking at the commit history, it seems like validateUniqueSchemasInModel() was renamed to validateUniqueElementsInModel(),  but the registration wasn’t updated.

